### PR TITLE
Componente de dialog ao clicar 2x num livro para empréstimo criado

### DIFF
--- a/frontend/src/app/dashboard/livros/dashboard-table.tsx
+++ b/frontend/src/app/dashboard/livros/dashboard-table.tsx
@@ -12,10 +12,15 @@ import { Book } from "@/models/book";
 import { books as booksProvided } from "@/models/books-provider";
 import DeleteBook from "./delete-book";
 import EditBook from "./edit-book-modal";
+import { useState } from "react";
+import { LendBookDialog } from "./lend-book-dialog";
 
 export default function DashboardTable() {
   let books: Book[] = [];
   const { data, isLoading, error } = useBooks();
+
+  const [isLendDialogOpen, setIsLendDialogOpen] = useState(false);
+  const [selectedBook, setSelectedBook] = useState<Book | null>(null);
 
   if (data) {
     books = data;
@@ -28,6 +33,15 @@ export default function DashboardTable() {
   if (error) {
     books = booksProvided;
   }
+
+    const handleDoubleClick = (book: Book) => {
+    setSelectedBook(book);
+    setIsLendDialogOpen(true);
+  };
+  const handleConfirmLend = (bookId: string) => {
+    console.log(`Iniciando processo de empréstimo para o livro ID: ${bookId}`);
+    setIsLendDialogOpen(false);
+  };
 
   return (
     <div>
@@ -42,8 +56,10 @@ export default function DashboardTable() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {books.map(book => (
-            <TableRow key={book.id}>
+          {books.map((book) => (
+            <TableRow key={book.id}
+            onDoubleClick={() => handleDoubleClick(book)}
+            className="cursor-pointer hover:bg-muted/50 transition-colors">
               <TableCell>{book.titulo}</TableCell>
               <TableCell>{book.autor}</TableCell>
               <TableCell>{book.avaliacao}</TableCell>
@@ -57,6 +73,13 @@ export default function DashboardTable() {
           ))}
         </TableBody>
       </Table>
+
+      <LendBookDialog
+        isOpen={isLendDialogOpen}
+        onOpenChange={setIsLendDialogOpen}
+        book={selectedBook}
+        onConfirmLend={handleConfirmLend}
+      />
     </div>
   );
 }

--- a/frontend/src/app/dashboard/livros/lend-book-dialog.tsx
+++ b/frontend/src/app/dashboard/livros/lend-book-dialog.tsx
@@ -1,0 +1,48 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Book } from "@/models/book";
+
+interface LendBookDialogProps {
+  book: Book | null;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirmLend: (bookId: number) => void;
+}
+
+export function LendBookDialog({ book, isOpen, onOpenChange, onConfirmLend }: LendBookDialogProps) {
+  if (!book) {
+    return null;
+  }
+
+  const handleConfirm = () => {
+    onConfirmLend(book.id);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>{book.titulo}</DialogTitle>
+          <DialogDescription className="pt-2 max-h-[50vh] overflow-y-auto">
+            {book.sinopse || "Este livro não possui sinopse."}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button type="button" onClick={handleConfirm}>
+            Emprestar Livro
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Falta implementar lógica de empréstimo no botão, mas o frontend está pronto. Implementado na tela de gerenciamento de livros (dashboard/livros).

![exemplo1](https://github.com/user-attachments/assets/0390bfaf-08e7-4d6f-8edb-344e3b7c9592)
![exemplo2](https://github.com/user-attachments/assets/6f437be2-eff4-421c-a79b-90996259ce31)
